### PR TITLE
Fix required tag interpretation for map fields

### DIFF
--- a/zod.go
+++ b/zod.go
@@ -576,7 +576,6 @@ forParts:
 		} else {
 			if valValue != "" {
 				switch valName {
-				case "required":
 				case "min":
 					validateStr.WriteString(fmt.Sprintf(".min(%s)", valValue))
 				case "max":
@@ -713,7 +712,6 @@ forParts:
 			switch valName {
 			case "omitempty":
 			case "required":
-				refines = append(refines, ".refine((val) => Object.keys(val).length > 0, 'Empty map')")
 			case "dive":
 				break forParts
 

--- a/zod_test.go
+++ b/zod_test.go
@@ -1330,7 +1330,7 @@ func TestMapWithValidations(t *testing.T) {
 	}
 	assert.Equal(t,
 		`export const RequiredSchema = z.object({
-  Map: z.record(z.string(), z.string()).refine((val) => Object.keys(val).length > 0, 'Empty map'),
+  Map: z.record(z.string(), z.string()),
 })
 export type Required = z.infer<typeof RequiredSchema>
 
@@ -1720,7 +1720,7 @@ export const UserSchema = z.object({
   PostOptional: PostSchema.optional(),
   PostOptionalNullable: PostSchema.optional().nullable(),
   Metadata: z.record(z.string(), z.string()).nullable(),
-  MetadataLength: z.record(z.string(), z.string()).refine((val) => Object.keys(val).length > 0, 'Empty map').refine((val) => Object.keys(val).length >= 1, 'Map too small').refine((val) => Object.keys(val).length <= 10, 'Map too large'),
+  MetadataLength: z.record(z.string(), z.string()).refine((val) => Object.keys(val).length >= 1, 'Map too small').refine((val) => Object.keys(val).length <= 10, 'Map too large'),
   MetadataOptional: z.record(z.string(), z.string()).optional(),
   MetadataOptionalNullable: z.record(z.string(), z.string()).optional().nullable(),
   ExtendedProps: z.any(),


### PR DESCRIPTION
By default map fields are considered nullable. With 'required', they are not nullable but can be empty. But the current implementation enforced 'required' maps to be non-empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined validation by removing redundant checks for collection requirements, ensuring that map validations now only enforce minimum and maximum size constraints.
- **Tests**
  - Updated tests to align with the simplified validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->