### PR TITLE
Fix schema generation for embedded recursive structs

### DIFF
--- a/zod.go
+++ b/zod.go
@@ -947,27 +947,27 @@ func (c *Converter) validateString(validate string) string {
 				// const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);
 				validateStr.WriteString(fmt.Sprintf(".enum([\"%s\"] as const)", strings.Join(vals, "\", \"")))
 			case "len":
-				validateStr.WriteString(fmt.Sprintf(".length(%s)", valValue))
+				refines = append(refines, fmt.Sprintf(".refine((val) => [...val].length === %s, 'String must contain %s character(s)')", valValue, valValue))
 			case "min":
-				validateStr.WriteString(fmt.Sprintf(".min(%s)", valValue))
+				refines = append(refines, fmt.Sprintf(".refine((val) => [...val].length >= %s, 'String must contain at least %s character(s)')", valValue, valValue))
 			case "max":
-				validateStr.WriteString(fmt.Sprintf(".max(%s)", valValue))
+				refines = append(refines, fmt.Sprintf(".refine((val) => [...val].length <= %s, 'String must contain at most %s character(s)')", valValue, valValue))
 			case "gt":
 				val, err := strconv.Atoi(valValue)
 				if err != nil {
 					panic("gt= must be followed by a number")
 				}
-				validateStr.WriteString(fmt.Sprintf(".min(%d)", val+1))
+				refines = append(refines, fmt.Sprintf(".refine((val) => [...val].length > %d, 'String must contain at least %d character(s)')", val, val+1))
 			case "gte":
-				validateStr.WriteString(fmt.Sprintf(".min(%s)", valValue))
+				refines = append(refines, fmt.Sprintf(".refine((val) => [...val].length >= %s, 'String must contain at least %s character(s)')", valValue, valValue))
 			case "lt":
 				val, err := strconv.Atoi(valValue)
 				if err != nil {
 					panic("lt= must be followed by a number")
 				}
-				validateStr.WriteString(fmt.Sprintf(".max(%d)", val-1))
+				refines = append(refines, fmt.Sprintf(".refine((val) => [...val].length < %d, 'String must contain at most %d character(s)')", val, val-1))
 			case "lte":
-				validateStr.WriteString(fmt.Sprintf(".max(%s)", valValue))
+				refines = append(refines, fmt.Sprintf(".refine((val) => [...val].length <= %s, 'String must contain at most %s character(s)')", valValue, valValue))
 			case "contains":
 				validateStr.WriteString(fmt.Sprintf(".includes(\"%s\")", valValue))
 			case "endswith":

--- a/zod.go
+++ b/zod.go
@@ -293,7 +293,7 @@ func (c *Converter) getStructShape(input reflect.Type, indent int) string {
 		if !shouldMerge {
 			output.WriteString(line)
 		} else {
-			output.WriteString(fmt.Sprintf("%s...%s.shape,\n", schemaName(c.prefix, typeName(field.Type)), line))
+			output.WriteString(fmt.Sprintf("%s...%s.shape,\n", indentation(indent+1), schemaName(c.prefix, typeName(field.Type))))
 		}
 	}
 

--- a/zod_test.go
+++ b/zod_test.go
@@ -394,10 +394,10 @@ func TestNullableWithValidations(t *testing.T) {
   PtrInt2: z.number().gte(2).lte(5),
   PtrIntNullable: z.number().gte(2).lte(5).nullable(),
   PtrStringOptional1: z.string().optional(),
-  PtrStringOptional2: z.string().min(2).max(5).optional(),
-  PtrString1: z.string().min(2).max(5),
-  PtrString2: z.string().min(2).max(5),
-  PtrStringNullable: z.string().min(2).max(5).nullable(),
+  PtrStringOptional2: z.string().refine((val) => [...val].length >= 2, 'String must contain at least 2 character(s)').refine((val) => [...val].length <= 5, 'String must contain at most 5 character(s)').optional(),
+  PtrString1: z.string().refine((val) => [...val].length >= 2, 'String must contain at least 2 character(s)').refine((val) => [...val].length <= 5, 'String must contain at most 5 character(s)'),
+  PtrString2: z.string().refine((val) => [...val].length >= 2, 'String must contain at least 2 character(s)').refine((val) => [...val].length <= 5, 'String must contain at most 5 character(s)'),
+  PtrStringNullable: z.string().refine((val) => [...val].length >= 2, 'String must contain at least 2 character(s)').refine((val) => [...val].length <= 5, 'String must contain at most 5 character(s)').nullable(),
 })
 export type User = z.infer<typeof UserSchema>
 
@@ -487,7 +487,7 @@ export type OneOfSeparated = z.infer<typeof OneOfSeparatedSchema>
 	}
 	assert.Equal(t,
 		`export const LenSchema = z.object({
-  Name: z.string().length(5),
+  Name: z.string().refine((val) => [...val].length === 5, 'String must contain 5 character(s)'),
 })
 export type Len = z.infer<typeof LenSchema>
 
@@ -499,7 +499,7 @@ export type Len = z.infer<typeof LenSchema>
 	}
 	assert.Equal(t,
 		`export const MinSchema = z.object({
-  Name: z.string().min(5),
+  Name: z.string().refine((val) => [...val].length >= 5, 'String must contain at least 5 character(s)'),
 })
 export type Min = z.infer<typeof MinSchema>
 
@@ -511,7 +511,7 @@ export type Min = z.infer<typeof MinSchema>
 	}
 	assert.Equal(t,
 		`export const MaxSchema = z.object({
-  Name: z.string().max(5),
+  Name: z.string().refine((val) => [...val].length <= 5, 'String must contain at most 5 character(s)'),
 })
 export type Max = z.infer<typeof MaxSchema>
 
@@ -523,7 +523,7 @@ export type Max = z.infer<typeof MaxSchema>
 	}
 	assert.Equal(t,
 		`export const MinMaxSchema = z.object({
-  Name: z.string().min(3).max(7),
+  Name: z.string().refine((val) => [...val].length >= 3, 'String must contain at least 3 character(s)').refine((val) => [...val].length <= 7, 'String must contain at most 7 character(s)'),
 })
 export type MinMax = z.infer<typeof MinMaxSchema>
 
@@ -535,7 +535,7 @@ export type MinMax = z.infer<typeof MinMaxSchema>
 	}
 	assert.Equal(t,
 		`export const GtSchema = z.object({
-  Name: z.string().min(6),
+  Name: z.string().refine((val) => [...val].length > 5, 'String must contain at least 6 character(s)'),
 })
 export type Gt = z.infer<typeof GtSchema>
 
@@ -547,7 +547,7 @@ export type Gt = z.infer<typeof GtSchema>
 	}
 	assert.Equal(t,
 		`export const GteSchema = z.object({
-  Name: z.string().min(5),
+  Name: z.string().refine((val) => [...val].length >= 5, 'String must contain at least 5 character(s)'),
 })
 export type Gte = z.infer<typeof GteSchema>
 
@@ -559,7 +559,7 @@ export type Gte = z.infer<typeof GteSchema>
 	}
 	assert.Equal(t,
 		`export const LtSchema = z.object({
-  Name: z.string().max(4),
+  Name: z.string().refine((val) => [...val].length < 5, 'String must contain at most 4 character(s)'),
 })
 export type Lt = z.infer<typeof LtSchema>
 
@@ -571,7 +571,7 @@ export type Lt = z.infer<typeof LtSchema>
 	}
 	assert.Equal(t,
 		`export const LteSchema = z.object({
-  Name: z.string().max(5),
+  Name: z.string().refine((val) => [...val].length <= 5, 'String must contain at most 5 character(s)'),
 })
 export type Lte = z.infer<typeof LteSchema>
 
@@ -1456,7 +1456,7 @@ export type Lte = z.infer<typeof LteSchema>
 	}
 	assert.Equal(t,
 		`export const Dive1Schema = z.object({
-  Map: z.record(z.string(), z.string().min(2)).nullable(),
+  Map: z.record(z.string(), z.string().refine((val) => [...val].length >= 2, 'String must contain at least 2 character(s)')).nullable(),
 })
 export type Dive1 = z.infer<typeof Dive1Schema>
 
@@ -1467,7 +1467,7 @@ export type Dive1 = z.infer<typeof Dive1Schema>
 	}
 	assert.Equal(t,
 		`export const Dive2Schema = z.object({
-  Map: z.record(z.string(), z.string().min(3)).refine((val) => Object.keys(val).length >= 2, 'Map too small').array(),
+  Map: z.record(z.string(), z.string().refine((val) => [...val].length >= 3, 'String must contain at least 3 character(s)')).refine((val) => Object.keys(val).length >= 2, 'Map too small').array(),
 })
 export type Dive2 = z.infer<typeof Dive2Schema>
 
@@ -1478,7 +1478,7 @@ export type Dive2 = z.infer<typeof Dive2Schema>
 	}
 	assert.Equal(t,
 		`export const Dive3Schema = z.object({
-  Map: z.record(z.string().min(3), z.string().max(4)).refine((val) => Object.keys(val).length >= 2, 'Map too small').array(),
+  Map: z.record(z.string().refine((val) => [...val].length >= 3, 'String must contain at least 3 character(s)'), z.string().refine((val) => [...val].length <= 4, 'String must contain at most 4 character(s)')).refine((val) => Object.keys(val).length >= 2, 'Map too small').array(),
 })
 export type Dive3 = z.infer<typeof Dive3Schema>
 

--- a/zod_test.go
+++ b/zod_test.go
@@ -2020,14 +2020,15 @@ func TestRecursive1(t *testing.T) {
   project_id: number,
   children: NestedItem[] | null,
 }
-export const NestedItemSchema: z.ZodType<NestedItem> = z.object({
+const NestedItemSchemaShape = {
   id: z.number(),
   title: z.string(),
   pos: z.number(),
   parent_id: z.number(),
   project_id: z.number(),
   children: z.lazy(() => NestedItemSchema).array().nullable(),
-})
+}
+export const NestedItemSchema: z.ZodType<NestedItem> = z.object(NestedItemSchemaShape)
 
 `, StructToZodSchema(NestedItem{}))
 }
@@ -2046,10 +2047,11 @@ func TestRecursive2(t *testing.T) {
   value: number,
   next: Node | null,
 }
-export const NodeSchema: z.ZodType<Node> = z.object({
+const NodeSchemaShape = {
   value: z.number(),
   next: z.lazy(() => NodeSchema).nullable(),
-})
+}
+export const NodeSchema: z.ZodType<Node> = z.object(NodeSchemaShape)
 
 export const ParentSchema = z.object({
   child: NodeSchema.nullable(),
@@ -2181,4 +2183,80 @@ export const RequestSchema = z.object({
 export type Request = z.infer<typeof RequestSchema>
 
 `, NewConverterWithOpts(WithCustomTags(customTagHandlers)).Convert(Request{}))
+}
+
+func TestRecursiveEmbeddedStruct(t *testing.T) {
+	type ItemA struct {
+		Name     string
+		Children []ItemA
+	}
+
+	type ItemB struct {
+		ItemA
+	}
+
+	type ItemC struct {
+		ItemB
+	}
+
+	type ItemD struct {
+		ItemA ItemA
+	}
+
+	type ItemE struct {
+		ItemA
+		Children []ItemE
+	}
+
+	type ItemF struct {
+		ItemE
+	}
+
+	c := NewConverterWithOpts()
+	c.AddType(ItemA{})
+	c.AddType(ItemB{})
+	c.AddType(ItemC{})
+	c.AddType(ItemD{})
+	c.AddType(ItemE{})
+	c.AddType(ItemF{})
+
+	assert.Equal(t, `export type ItemA = {
+  Name: string,
+  Children: ItemA[] | null,
+}
+const ItemASchemaShape = {
+  Name: z.string(),
+  Children: z.lazy(() => ItemASchema).array().nullable(),
+}
+export const ItemASchema: z.ZodType<ItemA> = z.object(ItemASchemaShape)
+
+export const ItemBSchema = z.object({
+  ...ItemASchemaShape,
+})
+export type ItemB = z.infer<typeof ItemBSchema>
+
+export const ItemCSchema = z.object({
+}).merge(ItemBSchema)
+export type ItemC = z.infer<typeof ItemCSchema>
+
+export const ItemDSchema = z.object({
+  ItemA: ItemASchema,
+})
+export type ItemD = z.infer<typeof ItemDSchema>
+
+export type ItemE = ItemA & {
+  Children: ItemE[] | null,
+}
+const ItemESchemaShape = {
+  ...ItemASchemaShape,
+  Children: z.lazy(() => ItemESchema).array().nullable(),
+}
+export const ItemESchema: z.ZodType<ItemE> = z.object(ItemESchemaShape)
+
+export const ItemFSchema = z.object({
+  ...ItemESchemaShape,
+})
+export type ItemF = z.infer<typeof ItemFSchema>
+
+`, c.Export())
 }

--- a/zod_test.go
+++ b/zod_test.go
@@ -2205,6 +2205,7 @@ func TestRecursiveEmbeddedStruct(t *testing.T) {
 
 	type ItemE struct {
 		ItemA
+		ItemD
 		Children []ItemE
 	}
 
@@ -2244,11 +2245,12 @@ export const ItemDSchema = z.object({
 })
 export type ItemD = z.infer<typeof ItemDSchema>
 
-export type ItemE = ItemA & {
+export type ItemE = ItemA & ItemD & {
   Children: ItemE[] | null,
 }
 const ItemESchemaShape = {
   ...ItemASchemaShape,
+  ...ItemDSchema.shape,
   Children: z.lazy(() => ItemESchema).array().nullable(),
 }
 export const ItemESchema: z.ZodType<ItemE> = z.object(ItemESchemaShape)


### PR DESCRIPTION
This should fix https://github.com/Hypersequent/zen/issues/16 following https://github.com/colinhacks/zod/discussions/2984

Note that recursive schema handling is much simpler in [v4 of zod](https://zod.dev/api?id=recursive-objects). We won't have the need to handle recursive types differently (so a lot of code can be cleaned up) and we won't even get the current issue. Maybe we can support v4 of zod in v2 of zen