### PR TITLE
Add Claude Code and PR review workflows

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,102 @@
+Perform a comprehensive code review of this pull request using specialized subagents, then post inline comments.
+
+Use the **Owner**, **Repository**, and **Pull Request Number** from the context provided by the caller for all API calls below.
+
+## Time & Error Budget
+- **Bash tool timeouts:** Set `timeout: 30000` (30 s) on every Bash tool call that runs a `gh` command. This prevents a single hanging API call from burning through the entire job timeout.
+- **API call failures (401, 403, 5xx, or timeout):** Retry at most **once**. If the retry also fails, skip that operation and move on. Do NOT keep retrying — a failed token will not recover.
+- **Subagent timeout:** Set `max_turns: 10` on each subagent to prevent any single reviewer from consuming too many turns.
+- **Prefer parallel calls:** Whenever multiple independent API calls are needed (e.g., fetching comments + reviews), batch them into a single turn.
+
+## Step 1: Gather Context (avoid anchoring/bias from prior bot output)
+1. Use `gh pr view` to get the PR title, body, and linked issues
+2. If the PR body contains issue references (e.g., "Fixes #123", "Closes #123"), use `gh issue view <number>` to understand the requirements
+3. Use `mcp__github__get_pull_request_diff` to get the full diff (paginate if needed)
+4. Do NOT fetch/read existing review comments. Subagents should review the diff independently. Cleanup of outdated bot comments is handled by a separate workflow step.
+
+## Step 2: Launch Specialized Review Subagents
+Use the Task tool to launch these subagents IN PARALLEL. Each subagent should analyze the PR diff and return a list of specific issues with file paths and line numbers.
+
+**Subagent 1: Code Quality Reviewer**
+```
+Review the PR for code quality issues:
+- Clean code principles: naming, function size, single responsibility
+- Code duplication and DRY violations
+- Error handling completeness and edge cases
+- Code readability and maintainability
+- Magic numbers/strings that should be constants
+- Commented-out code or debug statements
+
+For Go code: Check for proper use of `validate` struct tags (NOT `binding`), correct error handling patterns, proper Bun ORM usage.
+For TypeScript/Svelte: Check for proper types (avoid `any`), top-level `import type`, Zod validation usage.
+
+Return ONLY noteworthy issues with: file path, line number, issue description, suggested fix.
+```
+
+**Subagent 2: Security Reviewer**
+```
+Review the PR for security vulnerabilities:
+- OWASP Top 10: injection, XSS, broken auth, sensitive data exposure
+- Input validation and sanitization at system boundaries
+- Authentication/authorization checks
+- Hardcoded credentials or secrets
+- SQL injection prevention
+- Insecure cryptographic practices
+- Path traversal vulnerabilities
+
+Return ONLY noteworthy issues with: file path, line number, severity (critical/high/medium/low), issue description, remediation.
+```
+
+**Subagent 3: Performance Reviewer**
+```
+Review the PR for performance issues:
+- Algorithmic complexity (O(n^2) or worse operations)
+- N+1 query problems and missing database indexes
+- Unnecessary computations or redundant operations
+- Memory leaks from unclosed resources
+- Missing caching or memoization opportunities
+- Blocking operations that should be async
+
+Return ONLY noteworthy issues with: file path, line number, issue description, performance impact, suggested optimization.
+```
+
+**Subagent 4: Test Coverage Reviewer**
+```
+Review the PR for test coverage:
+- Are new functions/methods adequately tested?
+- Missing edge case tests
+- Missing error path tests
+- Test quality (proper assertions, isolation, naming)
+
+Return ONLY noteworthy gaps with: file path, what's missing, suggested test case.
+```
+
+**Subagent 5: Database/Migration Reviewer** (if migrations are in the PR)
+```
+Review database migrations for:
+- Migration correctness and reversibility
+- Proper indexes for new queries
+- HQID7 format for new entities (CHAR(23) COLLATE "C" NOT NULL)
+- Potential data loss or breaking changes
+
+Return ONLY noteworthy issues with: file path, line number, issue description, suggested fix.
+```
+
+## Step 3: Aggregate and Post a SINGLE Review
+1. Collect all findings from subagents
+2. Filter to keep only genuinely noteworthy issues (skip minor style nitpicks)
+3. **IMPORTANT — Post ALL comments as ONE review using the pending review flow:**
+   a. Call `mcp__github__create_pending_pull_request_review` ONCE to start a pending review
+   b. Call `mcp__github__add_comment_to_pending_review` for ALL new noteworthy issues — call these IN PARALLEL in a single turn to save turns
+   c. Call `mcp__github__submit_pending_pull_request_review` ONCE with event type "REQUEST_CHANGES" if there are noteworthy issues (High to Critical severity), otherwise "APPROVE"
+   **DO NOT use `create_inline_comment` or `pull_request_review_write` — these create a separate review per comment.**
+
+NOTE: Cleanup of outdated bot threads, review summaries, and progress comments is handled by a separate workflow step. Do NOT perform cleanup here.
+
+## Guidelines
+- Be constructive and provide actionable suggestions
+- Focus on significant issues that could cause bugs, security vulnerabilities, or maintenance problems
+- Skip minor style issues that don't affect functionality
+- Use English for all comments
+- If no noteworthy issues are found, submit a brief approving comment
+- Keep the review concise and to the point to optimize for the reader's time.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -27,8 +27,7 @@ Review the PR for code quality issues:
 - Magic numbers/strings that should be constants
 - Commented-out code or debug statements
 
-For Go code: Check for proper use of `validate` struct tags (NOT `binding`), correct error handling patterns, proper Bun ORM usage.
-For TypeScript/Svelte: Check for proper types (avoid `any`), top-level `import type`, Zod validation usage.
+For Go code: Check for idiomatic error handling, proper use of struct tags, correct reflect usage, and Go naming conventions.
 
 Return ONLY noteworthy issues with: file path, line number, issue description, suggested fix.
 ```
@@ -51,11 +50,10 @@ Return ONLY noteworthy issues with: file path, line number, severity (critical/h
 ```
 Review the PR for performance issues:
 - Algorithmic complexity (O(n^2) or worse operations)
-- N+1 query problems and missing database indexes
 - Unnecessary computations or redundant operations
+- Excessive allocations or reflect overhead
 - Memory leaks from unclosed resources
 - Missing caching or memoization opportunities
-- Blocking operations that should be async
 
 Return ONLY noteworthy issues with: file path, line number, issue description, performance impact, suggested optimization.
 ```
@@ -69,17 +67,6 @@ Review the PR for test coverage:
 - Test quality (proper assertions, isolation, naming)
 
 Return ONLY noteworthy gaps with: file path, what's missing, suggested test case.
-```
-
-**Subagent 5: Database/Migration Reviewer** (if migrations are in the PR)
-```
-Review database migrations for:
-- Migration correctness and reversibility
-- Proper indexes for new queries
-- HQID7 format for new entities (CHAR(23) COLLATE "C" NOT NULL)
-- Potential data loss or breaking changes
-
-Return ONLY noteworthy issues with: file path, line number, issue description, suggested fix.
 ```
 
 ## Step 3: Aggregate and Post a SINGLE Review

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,86 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    timeout-minutes: 12
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Check if workflow file changed
+        id: check-workflow
+        run: |
+          CHANGED=$(gh pr diff "$PR_NUMBER" --name-only | grep -c '^\.github/workflows/claude-review\.yml$' || true)
+          echo "changed=$( [ "$CHANGED" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # When this workflow file changes in a PR, OIDC auth fails because
+          # the workflow version differs from main. Fall back to the workflow's
+          # GITHUB_TOKEN (comments appear as github-actions[bot] instead of claude-bot).
+          github_token: ${{ steps.check-workflow.outputs.changed == 'true' && github.token || '' }}
+
+          # Enable progress tracking for visual feedback
+          track_progress: true
+          # Stream full tool-call output to the Actions step log for debugging
+          show_full_output: true
+
+          prompt: |
+            ## Context
+            - Owner: ${{ github.repository_owner }}
+            - Repository: ${{ github.repository }}
+            - Pull Request Number: ${{ github.event.pull_request.number }}
+
+            Read and execute the code review instructions in `.claude/commands/review-pr.md`.
+            Use the context above for all API calls.
+
+          # Allowed tools organized by category:
+          # 1. Core:     Task, Read, Glob, Grep (read-only, no Edit/Write)
+          # 2. PRs:      read, list, search, get diff
+          # 3. Reviews:  pending create/add/submit, reply
+          #    NOTE: create_inline_comment and pull_request_review_write are intentionally
+          #    excluded — they create a separate review per comment. Use the pending review
+          #    flow (create → add comments → submit) to batch all comments into one review.
+          # 4. Repo:     file contents, tree, commits, code search
+          # 5. Issues:   read, list, search
+          # 6. CI/CD:    actions get, job logs
+          # 7. Security: code scanning, secret scanning, dependabot
+          # 8. Bash gh:  gh pr view/diff, gh issue view, gh api
+          claude_args: |
+            --model claude-opus-4-6
+            --max-turns 50
+            --allowedTools "Task,Read,Glob,Grep,mcp__github__get_pull_request,mcp__github__get_pull_request_diff,mcp__github__pull_request_read,mcp__github__list_pull_requests,mcp__github__search_pull_requests,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__add_reply_to_pull_request_comment,mcp__github__get_file_contents,mcp__github__get_repository_tree,mcp__github__list_commits,mcp__github__get_commit,mcp__github__search_code,mcp__github__issue_read,mcp__github__search_issues,mcp__github__list_issues,mcp__github__actions_get,mcp__github__get_job_logs,mcp__github__list_code_scanning_alerts,mcp__github__get_code_scanning_alert,mcp__github__list_secret_scanning_alerts,mcp__github__get_secret_scanning_alert,mcp__github__list_dependabot_alerts,mcp__github__get_dependabot_alert,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue view:*),Bash(gh api:*)"
+
+        env:
+          MAX_MCP_OUTPUT_TOKENS: '50000'
+
+      - name: Cleanup outdated bot reviews
+        # Run even on review failure to clean stale progress comments from prior cycles.
+        if: ${{ !cancelled() }}
+        run: python3 scripts/cleanup-pr-review.py "$OWNER" "$REPO_NAME" "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,76 @@
+name: Claude Code
+
+on:
+  # issue_comment also triggers for pull request comments, since PRs are issues in GitHub
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: claude-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.23.5'
+
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Enable progress tracking for visual feedback
+          track_progress: true
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Allowed tools organized by category:
+          #  1. Core:       Task, Read, Edit, Write, Glob, Grep, WebFetch
+          #  2. Bash build: go, git, git rebase, make, gofumpt, golangci-lint, ls
+          #  3. Bash gh:    gh pr view/diff, gh issue view, gh api
+          #  4. File ops:   commit_files, update_claude_comment
+          #  5. Issues:     read, write, comment, list, search
+          #  6. PRs:        read, create, update, branch sync, list, search
+          #  7. Reviews:    pending create/add/submit, reply
+          #     NOTE: create_inline_comment and pull_request_review_write are intentionally
+          #     excluded — they create a separate review per comment. Use the pending review
+          #     flow (create → add comments → submit) to batch all comments into one review.
+          #  8. Repo:       file contents, tree, commits, code search, branches
+          #  9. CI/CD:      actions get/list, job logs
+          # 10. Security:   code scanning, secret scanning, dependabot
+          claude_args: |
+            --model claude-opus-4-6
+            --max-turns 50
+            --append-system-prompt "IMPORTANT: You MUST read and follow the CLAUDE.md file at the root of the repository before starting any work. It contains critical project conventions, commands, and patterns you must adhere to. After making ANY code changes and BEFORE committing, you MUST run formatting, linting, and tests. Follow these steps: 1. Run gofumpt -w on changed .go files. 2. Run golangci-lint run and fix any reported issues. 3. Run make test and fix any failures. Do NOT commit code that has lint errors or test failures."
+            --allowedTools "Task,Read,Edit,Write,Glob,Grep,WebFetch,Bash(go *),Bash(make *),Bash(git *),Bash(git rebase:*),Bash(gofumpt *),Bash(golangci-lint *),Bash(ls *),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue view:*),Bash(gh api:*),mcp__github_file_ops__commit_files,mcp__github_file_ops__update_claude_comment,mcp__github__issue_read,mcp__github__issue_write,mcp__github__add_issue_comment,mcp__github__list_issues,mcp__github__search_issues,mcp__github__pull_request_read,mcp__github__create_pull_request,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,mcp__github__list_pull_requests,mcp__github__search_pull_requests,mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__add_reply_to_pull_request_comment,mcp__github__get_file_contents,mcp__github__get_repository_tree,mcp__github__list_commits,mcp__github__get_commit,mcp__github__search_code,mcp__github__create_branch,mcp__github__list_branches,mcp__github__actions_get,mcp__github__actions_list,mcp__github__get_job_logs,mcp__github__list_code_scanning_alerts,mcp__github__get_code_scanning_alert,mcp__github__list_secret_scanning_alerts,mcp__github__get_secret_scanning_alert,mcp__github__list_dependabot_alerts,mcp__github__get_dependabot_alert"
+
+        env:
+          MAX_MCP_OUTPUT_TOKENS: '50000'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,8 +10,16 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+       (github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     concurrency:
       group: claude-${{ github.event.issue.number }}
@@ -35,9 +43,13 @@ jobs:
           go-version: '^1.23.5'
 
       - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.63
+          install-mode: binary
+          skip-build-cache: true
+          skip-save-cache: true
+          args: --version
 
       - name: Run Claude Code
         id: claude

--- a/scripts/cleanup-pr-review.py
+++ b/scripts/cleanup-pr-review.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+Clean up outdated bot review noise from a GitHub pull request.
+
+The latest bot review is kept; older bot reviews are resolved/minimized.
+Progress tracking comments are deleted; other outdated bot issue comments
+are minimized as outdated.
+
+Only targets reviews/comments by claude[bot] and github-actions[bot].
+
+Usage: uv run scripts/cleanup-pr-review.py <owner> <repo> <pr_number>
+Requires: gh (authenticated)
+"""
+
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+# Bot logins we manage — other bots (e.g. gemini) are left untouched.
+# REST API returns logins with [bot] suffix; GraphQL returns them without.
+BOT_LOGINS_REST = {"claude[bot]", "github-actions[bot]"}
+BOT_LOGINS_GQL = {"claude", "github-actions"}
+
+MINIMIZE_MUTATION = """
+mutation($id: ID!) {
+  minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+    minimizedComment { isMinimized }
+  }
+}
+"""
+
+RESOLVE_THREAD_MUTATION = """
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { isResolved }
+  }
+}
+"""
+
+REVIEW_THREADS_QUERY = """
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(last: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            nodes {
+              author { login }
+              databaseId
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def gh(*args: str) -> str:
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def gh_api(endpoint: str, *, paginate: bool = False) -> list | dict:
+    args = ["api", endpoint]
+    if paginate:
+        # --slurp wraps each page in an outer array so json.loads can parse
+        # concatenated multi-page output (without it, [page1][page2] is invalid JSON).
+        args.extend(["--paginate", "--slurp"])
+    result = json.loads(gh(*args))
+    # --slurp produces [[...], [...], ...]; flatten into a single list.
+    if paginate and isinstance(result, list) and result and isinstance(result[0], list):
+        return [item for page in result for item in page]
+    return result
+
+
+def gh_graphql(query: str, **variables: str | int) -> dict:
+    args = ["api", "graphql", "-f", f"query={query}"]
+    for key, value in variables.items():
+        flag = "-F" if isinstance(value, int) else "-f"
+        args.extend([flag, f"{key}={value}"])
+    return json.loads(gh(*args))
+
+
+def gh_fire_and_forget(*args: str) -> None:
+    """Run a gh command. Errors are logged but not raised."""
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print(f"[warn] gh {' '.join(args[:3])}... failed (exit {result.returncode}): {result.stderr.strip()}", file=sys.stderr)
+
+
+def is_bot_rest(login: str) -> bool:
+    return login in BOT_LOGINS_REST
+
+
+def is_bot_gql(login: str | None) -> bool:
+    # GitHub returns author: null for deleted/ghost accounts.
+    return login is not None and login in BOT_LOGINS_GQL
+
+
+def classify_outdated_threads(
+    threads: list[dict],
+    outdated_comment_ids: set[int],
+    comment_id_to_review_id: dict[int, int],
+) -> tuple[list[str], set[int]]:
+    """Single pass over threads: return (thread_ids_to_resolve, protected_review_ids).
+
+    Threads whose first comment belongs to an outdated bot review are classified:
+    - All-bot threads → resolve them.
+    - Threads with human comments → protect their parent review from minimization.
+    """
+    to_resolve: list[str] = []
+    protected: set[int] = set()
+
+    for thread in threads:
+        if thread["isResolved"]:
+            continue
+        comments = thread["comments"]["nodes"]
+        if not comments:
+            continue
+        first_db_id = comments[0]["databaseId"]
+        if first_db_id not in outdated_comment_ids:
+            continue
+
+        all_bots = all(
+            is_bot_gql(c["author"]["login"] if c.get("author") else None)
+            for c in comments
+        )
+        if all_bots:
+            to_resolve.append(thread["id"])
+        else:
+            review_id = comment_id_to_review_id.get(first_db_id)
+            if review_id is not None:
+                protected.add(review_id)
+
+    return to_resolve, protected
+
+
+def resolve_threads(thread_ids: list[str]) -> int:
+    """Resolve the given review threads concurrently."""
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        for tid in thread_ids:
+            pool.submit(
+                gh_fire_and_forget,
+                "api", "graphql",
+                "-f", f"query={RESOLVE_THREAD_MUTATION}",
+                "-f", f"threadId={tid}",
+            )
+    return len(thread_ids)
+
+
+def minimize_outdated_reviews(
+    bot_reviews: list[dict],
+    protected_review_ids: set[int],
+) -> int:
+    """Minimize outdated bot review summaries, skipping protected ones."""
+    outdated = [
+        r for r in bot_reviews[1:]
+        if r.get("body")
+        and r["id"] not in protected_review_ids
+    ]
+
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        for review in outdated:
+            pool.submit(
+                gh_fire_and_forget,
+                "api", "graphql",
+                "-f", f"query={MINIMIZE_MUTATION}",
+                "-f", f"id={review['node_id']}",
+            )
+
+    return len(outdated)
+
+
+def cleanup_issue_comments(owner: str, repo: str, pr_number: int) -> None:
+    """Delete progress tracking comments and minimize outdated bot issue comments."""
+    print("Fetching issue comments...")
+    issue_comments: list[dict] = gh_api(
+        f"repos/{owner}/{repo}/issues/{pr_number}/comments", paginate=True
+    )
+
+    bot_comments = [c for c in issue_comments if is_bot_rest(c["user"]["login"])]
+
+    # Partition into progress comments and substantive comments.
+    # These patterns match comments created by anthropics/claude-code-action
+    # with track_progress: true. Update if that action changes its format.
+    progress_comments: list[dict] = []
+    substantive_comments: list[dict] = []
+    for c in bot_comments:
+        body = c.get("body", "")
+        is_progress = (
+            body.startswith("**Claude finished @")
+            or "Claude Code is working" in body
+            or body.startswith("### Code Review:")
+        )
+        if is_progress:
+            progress_comments.append(c)
+        else:
+            substantive_comments.append(c)
+
+    # Delete progress tracking comments (ephemeral, no value keeping them)
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        for c in progress_comments:
+            pool.submit(
+                gh_fire_and_forget,
+                "api", "-X", "DELETE",
+                f"repos/{owner}/{repo}/issues/comments/{c['id']}",
+            )
+    print(f"Deleted {len(progress_comments)} progress comment(s).")
+
+    # Minimize outdated bot issue comments (keep the most recent one)
+    sorted_substantive = sorted(
+        substantive_comments, key=lambda c: c["created_at"], reverse=True
+    )
+    outdated = sorted_substantive[1:]
+
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        for c in outdated:
+            pool.submit(
+                gh_fire_and_forget,
+                "api", "graphql",
+                "-f", f"query={MINIMIZE_MUTATION}",
+                "-f", f"id={c['node_id']}",
+            )
+    print(f"Minimized {len(outdated)} outdated issue comment(s).")
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <owner> <repo> <pr_number>", file=sys.stderr)
+        sys.exit(1)
+
+    owner = sys.argv[1]
+    repo = sys.argv[2]
+    pr_number = int(sys.argv[3])
+
+    # --- Step 1: Fetch all bot output ---
+    print("Fetching inline comments and reviews...")
+    comments: list[dict] = gh_api(
+        f"repos/{owner}/{repo}/pulls/{pr_number}/comments", paginate=True
+    )
+    reviews: list[dict] = gh_api(
+        f"repos/{owner}/{repo}/pulls/{pr_number}/reviews", paginate=True
+    )
+
+    # --- Step 2: Identify the latest bot review ---
+    bot_reviews = sorted(
+        [r for r in reviews if is_bot_rest(r["user"]["login"])],
+        key=lambda r: r["submitted_at"],
+        reverse=True,
+    )
+
+    print(f"Found {len(bot_reviews)} bot review(s).")
+
+    if len(bot_reviews) > 1:
+        latest_review_id = bot_reviews[0]["id"]
+        print(f"Latest bot review ID: {latest_review_id}")
+
+        # Comments belonging to non-latest bot reviews
+        outdated_comment_ids: set[int] = {
+            c["id"]
+            for c in comments
+            if is_bot_rest(c["user"]["login"])
+            and c["pull_request_review_id"] != latest_review_id
+        }
+
+        # --- Steps 3-4: Classify threads and clean up ---
+        print("Fetching review threads...")
+        threads_response = gh_graphql(
+            REVIEW_THREADS_QUERY,
+            owner=owner,
+            repo=repo,
+            pr=pr_number,
+        )
+        threads = (
+            threads_response["data"]["repository"]["pullRequest"]
+            ["reviewThreads"]["nodes"]
+        )
+
+        # Build mapping: comment databaseId -> pull_request_review_id
+        comment_id_to_review_id = {
+            c["id"]: c["pull_request_review_id"] for c in comments
+        }
+
+        thread_ids_to_resolve, protected = classify_outdated_threads(
+            threads, outdated_comment_ids, comment_id_to_review_id
+        )
+
+        resolved = resolve_threads(thread_ids_to_resolve)
+        print(f"Resolved {resolved} outdated thread(s).")
+
+        minimized = minimize_outdated_reviews(bot_reviews, protected)
+        print(f"Minimized {minimized} outdated review summary(ies).")
+    else:
+        print("Skipping thread resolution and review minimization (need >1 bot review).")
+
+    # --- Step 5: Clean up bot issue comments ---
+    cleanup_issue_comments(owner, repo, pr_number)
+
+    print("Cleanup complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `claude.yml` workflow for handling @claude mentions in issues and PR comments
- Add `claude-review.yml` workflow for automated PR reviews on open/sync/reopen
- Add `.claude/commands/review-pr.md` with subagent-based review (code quality, security, performance, tests, DB migrations)
- Add `scripts/cleanup-pr-review.py` to minimize outdated bot review noise

Adapted from the tms repo workflows — replaced pnpm/turbo/namespace runners with Go toolchain (setup-go, golangci-lint, gofumpt) on ubuntu-latest.

## Test plan
- [ ] Verify `CLAUDE_CODE_OAUTH_TOKEN` secret is configured in repo settings
- [ ] Open a test PR to confirm `claude-review.yml` triggers and posts a review
- [ ] Comment `@claude` on an issue to confirm `claude.yml` triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)