### PR TITLE
Support skipping fields from generated schema via `zen:"ignore"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,33 @@ opt := zen.WithIgnoreTags("identifier")
 c := zen.NewConverterWithOpts(opt)
 ```
 
+## Skipping Fields
+
+A field can be excluded from the generated schema and type with the `zen:"ignore"` struct tag:
+
+```go
+type User struct {
+	Name string
+	// Kept in the JSON response for API backward compatibility, but the
+	// frontend no longer uses it, so omit it from the generated schema.
+	LegacyToken string `json:"legacyToken" zen:"ignore"`
+}
+```
+
+Outputs:
+
+```typescript
+export const UserSchema = z.object({
+	Name: z.string(),
+})
+export type User = z.infer<typeof UserSchema>
+```
+
+This differs from `json:"-"` (which `zen` also honors): `json:"-"` drops the field from the JSON payload entirely, whereas `zen:"ignore"`
+leaves JSON serialization untouched and only removes the field from the generated schema and type. This is handy when a field must stay
+in the wire format - e.g. a deprecated field kept for backward compatibility with external API clients - but should not surface in your
+in-house frontend's types. `zen:"ignore"` also applies to embedded (anonymous) fields, which `json:"-"` cannot skip.
+
 ## Custom Types
 
 We can pass type name mappings to custom conversion functions:

--- a/testdata/TestStructWithIgnoredField.golden
+++ b/testdata/TestStructWithIgnoredField.golden
@@ -1,0 +1,7 @@
+// @typecheck
+export const UserSchema = z.object({
+  Name: z.string(),
+  Age: z.number(),
+})
+export type User = z.infer<typeof UserSchema>
+

--- a/zod.go
+++ b/zod.go
@@ -294,6 +294,9 @@ func (c *Converter) getStructShape(input reflect.Type, indent int) string {
 	fields := input.NumField()
 	for i := range fields {
 		field := input.Field(i)
+		if isFieldIgnored(field) {
+			continue
+		}
 		optional := isOptional(field)
 		nullable := isNullable(field)
 
@@ -323,6 +326,9 @@ func (c *Converter) convertStruct(input reflect.Type, indent int) string {
 	fields := input.NumField()
 	for i := range fields {
 		field := input.Field(i)
+		if isFieldIgnored(field) {
+			continue
+		}
 		optional := isOptional(field)
 		nullable := isNullable(field)
 
@@ -379,6 +385,9 @@ func (c *Converter) getTypeStruct(input reflect.Type, indent int) string {
 	ownFieldNames := map[string]bool{}
 	for i := range fields {
 		f := input.Field(i)
+		if isFieldIgnored(f) {
+			continue
+		}
 		if !f.Anonymous {
 			if name := fieldName(f); name != "-" {
 				ownFieldNames[name] = true
@@ -388,6 +397,9 @@ func (c *Converter) getTypeStruct(input reflect.Type, indent int) string {
 
 	for i := range fields {
 		field := input.Field(i)
+		if isFieldIgnored(field) {
+			continue
+		}
 		optional := isOptional(field)
 		nullable := isNullable(field)
 
@@ -1545,6 +1557,13 @@ func isInterface(field reflect.StructField) bool {
 		t = t.Elem()
 	}
 	return t.Kind() == reflect.Interface
+}
+
+// isFieldIgnored reports whether a struct field should be excluded from schema
+// and type generation entirely, via the `zen:"ignore"` struct tag. Unlike
+// `json:"-"`, this also applies to embedded (anonymous) fields.
+func isFieldIgnored(field reflect.StructField) bool {
+	return field.Tag.Get("zen") == "ignore"
 }
 
 func isOptional(field reflect.StructField) bool {

--- a/zod_test.go
+++ b/zod_test.go
@@ -151,6 +151,20 @@ func TestStructSimpleWithOmittedField(t *testing.T) {
 	assertSchema(t, User{})
 }
 
+func TestStructWithIgnoredField(t *testing.T) {
+	type HasSecret struct {
+		Secret string
+	}
+	type User struct {
+		Name      string
+		Age       int
+		Internal  string `zen:"ignore"`
+		Password  string `zen:"ignore" json:"password"`
+		HasSecret `       zen:"ignore"`
+	}
+	assertSchema(t, User{})
+}
+
 func TestStructSimplePrefix(t *testing.T) {
 	type User struct {
 		Name   string


### PR DESCRIPTION
Add a `zen:"ignore"` struct tag that excludes a field from the generated Zod schema and TypeScript type. Unlike `json:"-"`, it leaves JSON serialization untouched and also works on embedded (anonymous) fields - useful for fields that must stay on the wire (e.g. deprecated fields kept for API compatibility) but shouldn't surface in the generated types.