### PR TITLE
Fix v4 http_url schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ fmt.Print(zen.StructToZodSchema(User{}, zen.WithZodV3()))
 
 The main migration differences are:
 
-- string format tags such as `email`, `http_url`, `ipv4`, `uuid4`, and `md5` now use Zod v4 helpers like `z.email()`, `z.httpUrl()`, `z.ipv4()`, `z.uuid({ version: "v4" })`, and `z.hash("md5")`
+- string format tags such as `email`, `http_url`, `ipv4`, `uuid4`, and `md5` now use Zod v4 helpers like `z.email()`, `z.url({ protocol: /^https?$/ })`, `z.ipv4()`, `z.uuid({ version: "v4" })`, and `z.hash("md5")`
 - `ip` and `ip_addr` now emit `z.union([z.ipv4(), z.ipv6()])`
 - embedded anonymous structs now expand through `.shape` spreads instead of `.merge(...)`
 - enum-like map keys now emit `z.partialRecord(...)`

--- a/testdata/TestFormatValidators/format_only/v4.golden
+++ b/testdata/TestFormatValidators/format_only/v4.golden
@@ -11,7 +11,7 @@ export const urlSchema = z.object({
 export type url = z.infer<typeof urlSchema>
 
 export const http_urlSchema = z.object({
-  value: z.string().check(z.httpUrl()),
+  value: z.string().check(z.url({ protocol: /^https?$/ })),
 })
 export type http_url = z.infer<typeof http_urlSchema>
 

--- a/testdata/TestFormatValidators/format_with_required/v4.golden
+++ b/testdata/TestFormatValidators/format_with_required/v4.golden
@@ -11,7 +11,7 @@ export const urlSchema = z.object({
 export type url = z.infer<typeof urlSchema>
 
 export const http_urlSchema = z.object({
-  value: z.string().min(1).check(z.httpUrl()),
+  value: z.string().min(1).check(z.url({ protocol: /^https?$/ })),
 })
 export type http_url = z.infer<typeof http_urlSchema>
 

--- a/testdata/TestZodV4Defaults/string_formats_use_zod_v4_builders.golden
+++ b/testdata/TestZodV4Defaults/string_formats_use_zod_v4_builders.golden
@@ -2,7 +2,7 @@
 // @typecheck
 export const PayloadSchema = z.object({
   Email: z.string().check(z.email()),
-  Link: z.string().check(z.httpUrl()),
+  Link: z.string().check(z.url({ protocol: /^https?$/ })),
   Base64: z.string().check(z.base64()),
   ID: z.string().check(z.uuid({ version: "v4" })),
   Checksum: z.string().check(z.hash("md5")),

--- a/tests/cases.ts
+++ b/tests/cases.ts
@@ -1462,7 +1462,10 @@ export const cases: TestCase[] = [
 		success: false,
 	},
 
-	// --- http_urlSchema (z.httpUrl() only accepts http/https) zod 3 accepts any URL ---
+	// --- http_urlSchema (z.url({ protocol: /^https?$/ }) only accepts http/https,
+	// but unlike z.httpUrl() does not require a dotted/TLD-style hostname —
+	// this mirrors go-playground/validator's http_url rule zod 3's .url() accepts
+	// any scheme. ---
 	{
 		name: "http_url: accepts https",
 		golden: "TestFormatValidators/format_only",
@@ -1496,6 +1499,34 @@ export const cases: TestCase[] = [
 		golden: "TestFormatValidators/format_only/v4.golden",
 		schema: "http_urlSchema",
 		input: { value: "mailto:user@example.com" },
+		success: false,
+	},
+	{
+		name: "http_url: v4 accepts localhost with port",
+		golden: "TestFormatValidators/format_only/v4.golden",
+		schema: "http_urlSchema",
+		input: { value: "https://localhost:8080/path" },
+		success: true,
+	},
+	{
+		name: "http_url: v4 accepts IP address with port",
+		golden: "TestFormatValidators/format_only/v4.golden",
+		schema: "http_urlSchema",
+		input: { value: "http://127.0.0.1:9000/x" },
+		success: true,
+	},
+	{
+		name: "http_url: v4 accepts single-label intranet host",
+		golden: "TestFormatValidators/format_only/v4.golden",
+		schema: "http_urlSchema",
+		input: { value: "https://intranet-host/browse/X" },
+		success: true,
+	},
+	{
+		name: "http_url: v4 rejects missing host",
+		golden: "TestFormatValidators/format_only/v4.golden",
+		schema: "http_urlSchema",
+		input: { value: "http://" },
 		success: false,
 	},
 

--- a/zod.go
+++ b/zod.go
@@ -1134,7 +1134,7 @@ func (c *Converter) parseStringValidators(validate string) []stringValidator {
 		case valName == "omitempty":
 			// skip
 		case valName == "oneof" && valValue != "":
-			vals := splitParamsRegex.FindAllString(rawPart[len("oneof="):], -1)
+			vals := splitParamsRegex.FindAllString(valValue, -1)
 			for i := range vals {
 				vals[i] = escapeJSString(strings.ReplaceAll(vals[i], "'", ""))
 			}
@@ -1410,7 +1410,7 @@ func (c *Converter) renderV4FormatCheck(v stringValidator) string {
 	case "url":
 		return ".check(z.url())"
 	case "http_url":
-		return ".check(z.httpUrl())"
+		return ".check(z.url({ protocol: /^https?$/ }))"
 	case "ipv4", "ip4_addr":
 		return ".check(z.ipv4())"
 	case "ipv6", "ip6_addr":


### PR DESCRIPTION
In Zod v4 mode, `renderV4FormatCheck` mapped `validate:"http_url"` to `.check(z.httpUrl())`.

`z.httpUrl()` is shorthand for `z.url({ protocol: /^https?$/, hostname: z.regexes.domain })`, and the hostname regex only accepts dotted, TLD-style domains. But go-playground/validator's `http_url` rule is `url.Parse`-based: it only requires an `http`/`https` scheme and a non-empty host. The generated Zod schema therefore rejects values the Go validator accepts:

| Value                            | Go `http_url` | `z.httpUrl()` |
| -------------------------------- | ------------- | ------------- |
| `https://localhost:8080/path`    | valid         | **rejected**  |
| `http://127.0.0.1:9000/x`        | valid         | **rejected**  |
| `https://intranet-host/browse/X` | valid         | **rejected**  |
| `https://example.com/a?b=c`      | valid         | valid         |

The updated `.check(z.url({ protocol: /^https?$/ }))` now matches go-playground/validator's behavior